### PR TITLE
Fixed references to next states

### DIFF
--- a/rs-enrichment-service/statemachine/enrichment-template-express-3.asl.json
+++ b/rs-enrichment-service/statemachine/enrichment-template-express-3.asl.json
@@ -34,7 +34,7 @@
           "BackoffRate": 2
         }
       ],
-      "Next": "Notify Event Status: 4"
+      "Next": "Notify Event Status: 5"
     },
     "Service 2 Response": {
       "Type": "Task",
@@ -57,7 +57,7 @@
           "BackoffRate": 2
         }
       ],
-      "Next": "Notify Event Status: 4"
+      "Next": "Notify Event Status: 5"
     },
     "Notify Event Status: 5": {
       "Type": "Task",


### PR DESCRIPTION
Got an error when i tried to `sam deploy --guided`. References in the express-3 were wrong, probably a copy paste error from express-2